### PR TITLE
fix: build server with Debian 12 toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . /app
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm run build
 
-FROM rust:1 AS server
+FROM rust:1-bookworm AS server
 WORKDIR /usr/src/app
 COPY . .
 RUN cargo build --release


### PR DESCRIPTION
## 問題
`rust:1` の可変ベースでビルドしたバイナリが GLIBC_2.38 を要求し、Debian 12 の distroless runtime で起動できない。

## 修正
server builder を `rust:1-bookworm` に固定し、runtime の `gcr.io/distroless/cc-debian12` と Debian 世代を揃える。

## 検証
- `docker build --tag release-date-sorter:glibc-compat-test .`
- ビルド済みイメージを起動し、環境変数未設定で終了することを確認。`GLIBC_* not found` は発生しない。